### PR TITLE
Wrap customDateDecoder debug print

### DIFF
--- a/Sources/WrkstrmFoundation/JSON/JSONCoders.swift
+++ b/Sources/WrkstrmFoundation/JSON/JSONCoders.swift
@@ -129,7 +129,9 @@ private enum Decoding {
     let dateString: String = try decoder.singleValueContainer().decode(
       String.self
     )
+#if DEBUG
     print("🕒 Attempting to parse date: \(dateString)")
+#endif
     // Attempt to decode the date using various formats.
     if let date = DateFormatter.iso8601.date(from: dateString) {
       return date


### PR DESCRIPTION
## Summary
- update `customDateDecoder` so printing only occurs in debug builds

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688c448ea5d48333838aedc3637fd7e0