### PR TITLE
Refactor helpers to remove force unwraps

### DIFF
--- a/Sources/WrkstrmFoundation/Extensions/NumberFormatter+Localize.swift
+++ b/Sources/WrkstrmFoundation/Extensions/NumberFormatter+Localize.swift
@@ -67,32 +67,32 @@ extension NumberFormatter {
 /// A protocol to provide localized string representations of numeric values.
 public protocol LocalizedValues {
   /// Returns a localized string representation of the conforming numeric type as an integer.
-  func integerString() -> String
+  func integerString() -> String?
 }
 
 extension LocalizedValues {
   /// Default implementation of `integerString` for types conforming to `LocalizedValues`.
   ///
   /// It uses `NumberFormatter.integer` to convert the numeric value to a string.
-  /// Force unwrapping is used as the formatter should always successfully convert a number to a
-  /// string.
-  public func integerString() -> String {
-    NumberFormatter.integer.string(for: self)!  // swiftlint:disable:this force_unwrapping
+  /// Returns `nil` if the value cannot be converted.
+  public func integerString() -> String? {
+    NumberFormatter.integer.string(for: self)
   }
 
   /// Returns a localized string representation of the conforming numeric type as a double.
   ///
   /// It uses `NumberFormatter.double` to convert the numeric value to a string with two decimal
-  /// points.
-  public func doubleString() -> String {
-    NumberFormatter.double.string(for: self)!  // swiftlint:disable:this force_unwrapping
+  /// points. Returns `nil` if the value cannot be converted.
+  public func doubleString() -> String? {
+    NumberFormatter.double.string(for: self)
   }
 
   /// Returns a localized string representation of the conforming numeric type as currency.
   ///
   /// It uses `NumberFormatter.dollar` to format the numeric value in a currency style.
-  public func dollarString() -> String {
-    NumberFormatter.dollar.string(for: self)!  // swiftlint:disable:this force_unwrapping
+  /// Returns `nil` if the value cannot be converted.
+  public func dollarString() -> String? {
+    NumberFormatter.dollar.string(for: self)
   }
 }
 

--- a/Sources/WrkstrmFoundation/Extensions/URL+URLQueryItem.swift
+++ b/Sources/WrkstrmFoundation/Extensions/URL+URLQueryItem.swift
@@ -22,11 +22,11 @@ extension URL {
   /// ```
   ///
   /// - Parameter items: An array of `URLQueryItem` to be added to the URL.
-  /// - Returns: A new `URL` with the query items added.
-  public func withQueryItems(_ items: [URLQueryItem]) -> URL {
+  /// - Returns: A new `URL` with the query items added, or `nil` if the URL could not be constructed.
+  public func withQueryItems(_ items: [URLQueryItem]) -> URL? {
     var components: URLComponents? = .init(url: self, resolvingAgainstBaseURL: false)
     components?.queryItems = items
-    return (components?.url)!  // swiftlint:disable:this force_unwrapping
+    return components?.url
   }
 
   /// Creates a new URL by adding the specified query items to the existing URL.
@@ -35,8 +35,8 @@ extension URL {
   /// converting them into `URLQueryItem` objects and appending them to the URL.
   ///
   /// - Parameter items: A dictionary of `String` key-value pairs to be added as query parameters.
-  /// - Returns: A new `URL` with the query items added.
-  public func withQueryItems(_ items: [String: String]) -> URL {
+  /// - Returns: A new `URL` with the query items added, or `nil` if the URL could not be constructed.
+  public func withQueryItems(_ items: [String: String]) -> URL? {
     withQueryItems(
       items.reduce(into: [URLQueryItem]()) { queryItems, pair in
         queryItems.append(URLQueryItem(name: pair.key, value: pair.value))

--- a/Sources/WrkstrmFoundation/Persistence/CodableArchiver.swift
+++ b/Sources/WrkstrmFoundation/Persistence/CodableArchiver.swift
@@ -31,17 +31,25 @@ public struct CodableArchiver<T: Codable> {
   ///   - encoder: A custom `JSONEncoder` for encoding objects. Defaults to `.default`.
   ///   - decoder: A custom `JSONDecoder` for decoding objects. Defaults to `.default`.
   ///   - searchPathDomainMask: The domain mask to use when searching for the directory.
+  /// - Throws: `ArchiverError.directoryNotFound` if the directory cannot be located.
+  public enum ArchiverError: Error {
+    case directoryNotFound
+  }
+
   public init(
     key: AnyHashable,
     directory: FileManager.SearchPathDirectory,
     encoder: JSONEncoder = .default,
     decoder: JSONDecoder = .default,
     searchPathDomainMask: FileManager.SearchPathDomainMask = [.allDomainsMask],
-  ) {
+  ) throws {
     self.encoder = encoder
     self.decoder = decoder
-    // swiftlint:disable:next force_unwrapping
-    let archiveDirectory: URL = fileManager.urls(for: directory, in: searchPathDomainMask).first!
+    guard
+      let archiveDirectory = fileManager.urls(for: directory, in: searchPathDomainMask).first
+    else {
+      throw ArchiverError.directoryNotFound
+    }
     self.archiveDirectory = archiveDirectory.appendingPathComponent(String(key.description))
     self.key = key
   }

--- a/Sources/WrkstrmNetworking/URL+Common.swift
+++ b/Sources/WrkstrmNetworking/URL+Common.swift
@@ -4,12 +4,30 @@ import Foundation
 #endif
 
 extension URL {
-  // swiftlint:disable:next force_unwrapping
-  static let google: URL = .init(string: "http://www.google.com")!
+  /// Predefined URLs known to be valid at compile time.
+  static let google: URL = {
+    guard let url = URL(string: "http://www.google.com") else {
+      // These URLs are expected to be valid and should never fail.
+      preconditionFailure("Invalid google URL")
+    }
+    return url
+  }()
 
-  // swiftlint:disable:next force_unwrapping
-  static let apple: URL = .init(string: "http://apple.com")!
+  /// Predefined URLs known to be valid at compile time.
+  static let apple: URL = {
+    guard let url = URL(string: "http://apple.com") else {
+      // These URLs are expected to be valid and should never fail.
+      preconditionFailure("Invalid apple URL")
+    }
+    return url
+  }()
 
-  // swiftlint:disable:next force_unwrapping
-  static let reddit: URL = .init(string: "https://reddit.com")!
+  /// Predefined URLs known to be valid at compile time.
+  static let reddit: URL = {
+    guard let url = URL(string: "https://reddit.com") else {
+      // These URLs are expected to be valid and should never fail.
+      preconditionFailure("Invalid reddit URL")
+    }
+    return url
+  }()
 }


### PR DESCRIPTION
## Summary
- make URL query item helpers return optional URLs
- allow LocalizedValues to return optional strings
- throw error if codable archive directory can't be found
- use precondition for static common URLs, assuming they are always valid

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_688c44990e54833394a2176b3395eba3