### PR TITLE
Replace deprecated archiving API

### DIFF
--- a/Sources/WrkstrmFoundation/Persistence/CodableArchiver.swift
+++ b/Sources/WrkstrmFoundation/Persistence/CodableArchiver.swift
@@ -112,7 +112,16 @@ public struct CodableArchiver<T: Codable> {
       attributes: nil,
     )
 
-    return NSKeyedArchiver.archiveRootObject(data, toFile: filePathForKey(key ?? self.key))
+    guard let archiveData = try? NSKeyedArchiver.archivedData(
+      withRootObject: data,
+      requiringSecureCoding: false
+    ) else {
+      return false
+    }
+
+    let path = filePathForKey(key ?? self.key)
+    _ = fileManager.createFile(atPath: path, contents: archiveData, attributes: nil)
+    return true
   }
 
   /// Encodes and archives an array of objects of type `T` associated with the given key.
@@ -133,7 +142,16 @@ public struct CodableArchiver<T: Codable> {
       attributes: nil,
     )
 
-    return NSKeyedArchiver.archiveRootObject(encodedValues, toFile: filePathForKey(key ?? self.key))
+    guard let archiveData = try? NSKeyedArchiver.archivedData(
+      withRootObject: encodedValues,
+      requiringSecureCoding: false
+    ) else {
+      return false
+    }
+
+    let path = filePathForKey(key ?? self.key)
+    _ = fileManager.createFile(atPath: path, contents: archiveData, attributes: nil)
+    return true
   }
 
   /// Clears the archive by removing all items in the directory.

--- a/Tests/WrkstrmFoundationTests/CodableArchiverTests.swift
+++ b/Tests/WrkstrmFoundationTests/CodableArchiverTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import WrkstrmFoundation
+
+@Suite("CodableArchiver")
+struct CodableArchiverTests {
+
+  private var tempDirectory: URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  }
+
+  @Test
+  func archiveSingleObject() throws {
+    let url = tempDirectory.appendingPathComponent("object")
+    let archiver = CodableArchiver<TestCodableValue>(directory: url)
+    let value = TestCodableValue(value: "testValue")
+
+    #expect(archiver.set(value))
+    let result = archiver.get()
+    #expect(result == value)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveArray() throws {
+    let url = tempDirectory.appendingPathComponent("array")
+    let archiver = CodableArchiver<TestCodableValue>(directory: url)
+    let values = [TestCodableValue(value: "one"), TestCodableValue(value: "two")]
+
+    #expect(archiver.set(values))
+
+    let path = archiver.filePathForKey(archiver.key)
+    guard let archived = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [Data] else {
+      #expect(false)
+      return
+    }
+    let decoded = archived.compactMap { try? archiver.decoder.decode(TestCodableValue.self, from: $0) }
+    #expect(decoded == values)
+    try? archiver.clear()
+  }
+}

--- a/Tests/WrkstrmFoundationTests/TestCodableValue.swift
+++ b/Tests/WrkstrmFoundationTests/TestCodableValue.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct TestCodableValue: Codable, Equatable {
+  let value: String
+}
+

--- a/Tests/WrkstrmFoundationTests/TestCodableValue.swift
+++ b/Tests/WrkstrmFoundationTests/TestCodableValue.swift
@@ -3,4 +3,3 @@ import Foundation
 struct TestCodableValue: Codable, Equatable {
   let value: String
 }
-


### PR DESCRIPTION
## Summary
- use `archivedData(withRootObject:requiringSecureCoding:)` for archiving
- write archived data using `FileManager`
- add `CodableArchiver` unit tests
- extract test model into its own file to avoid placeholder names

## Testing
- `swift test --enable-test-discovery`


------
https://chatgpt.com/codex/tasks/task_e_688c449ab2d883339d452615e1c8bf68