### PR TITLE
Refactor networking test helpers

### DIFF
--- a/Tests/WrkstrmNetworkingTests/Support/MockEnvironment.swift
+++ b/Tests/WrkstrmNetworkingTests/Support/MockEnvironment.swift
@@ -1,0 +1,11 @@
+import Foundation
+@testable import WrkstrmNetworking
+
+struct MockEnvironment: HTTP.Environment {
+  var apiKey: String? = "key"
+  var headers: HTTP.Client.Headers = ["Env": "Header"]
+  var scheme: HTTP.Scheme = .https
+  var baseURLString: String = "example.com"
+  var apiVersion: String? = "v1"
+  var clientVersion: String? = "1"
+}

--- a/Tests/WrkstrmNetworkingTests/Support/MockURLProtocol.swift
+++ b/Tests/WrkstrmNetworkingTests/Support/MockURLProtocol.swift
@@ -1,0 +1,21 @@
+import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
+
+class MockURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var handler: (@Sendable (URLRequest) -> (HTTPURLResponse, Data))?
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+  override func startLoading() {
+    guard let handler = Self.handler else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    let (response, data) = handler(request)
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: data)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+  override func stopLoading() {}
+}

--- a/Tests/WrkstrmNetworkingTests/Support/SampleRequest.swift
+++ b/Tests/WrkstrmNetworkingTests/Support/SampleRequest.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import WrkstrmNetworking
+
+struct SampleRequest: HTTP.CodableURLRequest {
+  typealias ResponseType = [String: String]
+  typealias RequestBody = Body
+
+  struct Body: Codable, Equatable { let name: String }
+
+  var method: HTTP.Method { .post }
+  var path: String { "users" }
+  var body: Body? = .init(name: "Bob")
+  var options: HTTP.Request.Options = .init(
+    timeout: 10,
+    queryItems: [URLQueryItem(name: "debug", value: "true")],
+    headers: ["X-Test": "1"]
+  )
+}

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -1,11 +1,57 @@
+import Foundation
+#if os(Linux)
+  import FoundationNetworking
+#endif
 import Testing
 
 @testable import WrkstrmNetworking
+@testable import WrkstrmFoundation
+@testable import WrkstrmMain
 
 @Suite("WrkstrmNetworking")
 struct WrkstrmNetworkingTests {
+  // Helpers defined in Support/MockEnvironment.swift and Support/SampleRequest.swift
+
   @Test
-  func generateSingleFile() {
-    #expect(true)
+  func urlRequestEncoding() throws {
+    let env = MockEnvironment()
+    let request = SampleRequest()
+    let urlRequest = try request.asURLRequest(with: env, encoder: .snakecase)
+
+    #expect(urlRequest.httpMethod == "POST")
+    #expect(urlRequest.url?.absoluteString == "https://example.com/v1/users?debug=true")
+    #expect(urlRequest.value(forHTTPHeaderField: "X-Test") == "1")
+
+    let expectedBody = try JSONEncoder.snakecase.encode(SampleRequest.Body(name: "Bob"))
+    #expect(urlRequest.httpBody == expectedBody)
+  }
+
+  // MARK: - Error Handling
+
+  @Test
+  func errorResponseHandling() async {
+    URLProtocol.registerClass(MockURLProtocol.self)
+    defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
+
+    let env = MockEnvironment()
+    let client = HTTP.JSONClient(environment: env, json: (.snakecase, .snakecase))
+
+    MockURLProtocol.handler = { request in
+      let data = try! JSONSerialization.data(withJSONObject: ["message": "bad"], options: [])
+      let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+      return (response, data)
+    }
+
+    do {
+      _ = try await client.send(SampleRequest())
+      #expect(false, "Request should throw")
+    } catch {
+      switch error {
+      case is HTTP.ClientError:
+        #expect(true)
+      default:
+        #expect(false, "Unexpected error: \(error)")
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- move MockEnvironment, SampleRequest and MockURLProtocol into Support files
- reference support helpers from `WrkstrmNetworkingTests`

## Testing
- `swift test --disable-automatic-resolution`

------
https://chatgpt.com/codex/tasks/task_e_688c449db8208333b2800742d75a8b98