### PR TITLE
feat: improve linux networking compatibility

### DIFF
--- a/Sources/WrkstrmNetworking/CURL.swift
+++ b/Sources/WrkstrmNetworking/CURL.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WrkstrmLog
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/Data+JSONSerialization.swift
+++ b/Sources/WrkstrmNetworking/Data+JSONSerialization.swift
@@ -13,6 +13,7 @@ extension Data {
           with: self,
           options: [.mutableContainers]
         )
+        // swiftlint:disable:next force_cast
         as! JSON.AnyDictionary
       #if DEBUG
       if ProcessInfo.enableNetworkLogging {

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+Client.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+Client.swift
@@ -3,7 +3,7 @@ import WrkstrmFoundation
 import WrkstrmLog
 import WrkstrmMain
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+CodableClient.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+CodableClient.swift
@@ -3,7 +3,7 @@ import WrkstrmFoundation
 import WrkstrmLog
 import WrkstrmMain
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+EncodableRequest.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+EncodableRequest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+Environment.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+Environment.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+JSONClient.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+JSONClient.swift
@@ -3,7 +3,7 @@ import WrkstrmFoundation
 import WrkstrmLog
 import WrkstrmMain
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
@@ -2,7 +2,7 @@ import Foundation
 import WrkstrmFoundation
 import WrkstrmLog
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Sources/WrkstrmNetworking/URL+Common.swift
+++ b/Sources/WrkstrmNetworking/URL+Common.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 

--- a/Tests/WrkstrmNetworkingTests/Support/MockURLProtocol.swift
+++ b/Tests/WrkstrmNetworkingTests/Support/MockURLProtocol.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -30,15 +30,25 @@ struct WrkstrmNetworkingTests {
 
   @Test
   func errorResponseHandling() async {
-    let _ = URLProtocol.registerClass(MockURLProtocol.self)
+    _ = URLProtocol.registerClass(MockURLProtocol.self)
     defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
 
     let env = MockEnvironment()
     let client = HTTP.JSONClient(environment: env, json: (.snakecase, .snakecase))
 
     MockURLProtocol.handler = { request in
-      let data = try! JSONSerialization.data(withJSONObject: ["message": "bad"], options: [])
-      let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+      guard let data = try? JSONSerialization.data(
+        withJSONObject: ["message": "bad"],
+        options: []
+      ) else {
+        fatalError("Failed to encode error JSON")
+      }
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: 400,
+        httpVersion: nil,
+        headerFields: nil
+      )!
       return (response, data)
     }
 

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(Linux)
+#if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 import Testing
@@ -30,7 +30,7 @@ struct WrkstrmNetworkingTests {
 
   @Test
   func errorResponseHandling() async {
-    URLProtocol.registerClass(MockURLProtocol.self)
+    let _ = URLProtocol.registerClass(MockURLProtocol.self)
     defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
 
     let env = MockEnvironment()
@@ -44,13 +44,13 @@ struct WrkstrmNetworkingTests {
 
     do {
       _ = try await client.send(SampleRequest())
-      #expect(false, "Request should throw")
+      #expect(Bool(false), "Request should throw")
     } catch {
       switch error {
       case is HTTP.ClientError:
-        #expect(true)
+        #expect(Bool(true))
       default:
-        #expect(false, "Unexpected error: \(error)")
+        #expect(Bool(false), "Unexpected error: \(error)")
       }
     }
   }


### PR DESCRIPTION
## Summary
- rely on `canImport(FoundationNetworking)` so the networking module can build on Linux
- clean up network tests to avoid warnings and handle `URLProtocol.registerClass`

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688dbc7e49ac8333802c9890df777791