### PR TITLE
Replace deprecated archiving API

### DIFF
--- a/.github/workflows/wrkstrm-foundation-swiftlint.yml
+++ b/.github/workflows/wrkstrm-foundation-swiftlint.yml
@@ -43,7 +43,7 @@ jobs:
       if: steps.cache-brew.outputs.cache-hit != 'true'
       run: brew install swiftlint
     - name: Download SwiftLint Configuration
-      if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
+      if: matrix.os == 'macos-latest' || matrix.os == 'macos-15'
       run: curl -O https://raw.githubusercontent.com/wrkstrm/configs/main/.swiftlint.yml
     - name: SwiftLint
       run: swiftlint

--- a/.github/workflows/wrkstrm-foundation-swiftlint.yml
+++ b/.github/workflows/wrkstrm-foundation-swiftlint.yml
@@ -44,6 +44,6 @@ jobs:
       run: brew install swiftlint
     - name: Download SwiftLint Configuration
       if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
-      run: curl -O https://raw.githubusercontent.com/wrkstrm/WrkstrmConfig/main/.swiftlint.yml
+      run: curl -O https://raw.githubusercontent.com/wrkstrm/configs/main/.swiftlint.yml
     - name: SwiftLint
       run: swiftlint

--- a/Sources/WrkstrmFoundation/Persistence/CodableArchiver.swift
+++ b/Sources/WrkstrmFoundation/Persistence/CodableArchiver.swift
@@ -112,7 +112,16 @@ public struct CodableArchiver<T: Codable> {
       attributes: nil,
     )
 
-    return NSKeyedArchiver.archiveRootObject(data, toFile: filePathForKey(key ?? self.key))
+    guard let archiveData = try? NSKeyedArchiver.archivedData(
+      withRootObject: data,
+      requiringSecureCoding: false
+    ) else {
+      return false
+    }
+
+    let path = filePathForKey(key ?? self.key)
+    _ = fileManager.createFile(atPath: path, contents: archiveData, attributes: nil)
+    return true
   }
 
   /// Encodes and archives an array of objects of type `T` associated with the given key.
@@ -133,7 +142,16 @@ public struct CodableArchiver<T: Codable> {
       attributes: nil,
     )
 
-    return NSKeyedArchiver.archiveRootObject(encodedValues, toFile: filePathForKey(key ?? self.key))
+    guard let archiveData = try? NSKeyedArchiver.archivedData(
+      withRootObject: encodedValues,
+      requiringSecureCoding: false
+    ) else {
+      return false
+    }
+
+    let path = filePathForKey(key ?? self.key)
+    _ = fileManager.createFile(atPath: path, contents: archiveData, attributes: nil)
+    return true
   }
 
   /// Clears the archive by removing all items in the directory.

--- a/Tests/WrkstrmFoundationTests/CodableArchiverTests.swift
+++ b/Tests/WrkstrmFoundationTests/CodableArchiverTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+
+@testable import WrkstrmFoundation
+
+@Suite("CodableArchiver")
+struct CodableArchiverTests {
+
+  private var tempDirectory: URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  }
+
+  @Test
+  func archiveSingleObject() throws {
+    let url = tempDirectory.appendingPathComponent("object")
+    let archiver = CodableArchiver<TestCodableValue>(directory: url)
+    let value = TestCodableValue(value: "testValue")
+
+    #expect(archiver.set(value))
+    let result = archiver.get()
+    #expect(result == value)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveArray() throws {
+    let url = tempDirectory.appendingPathComponent("array")
+    let archiver = CodableArchiver<TestCodableValue>(directory: url)
+    let values = [TestCodableValue(value: "one"), TestCodableValue(value: "two")]
+
+    #expect(archiver.set(values))
+
+    let path = archiver.filePathForKey(archiver.key)
+    guard let archived = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [Data] else {
+      #expect(false)
+      return
+    }
+    let decoded = archived.compactMap { try? archiver.decoder.decode(TestCodableValue.self, from: $0) }
+    #expect(decoded == values)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveNestedStruct() throws {
+    struct Container: Codable, Equatable {
+      let id: Int
+      let values: [TestCodableValue]
+    }
+
+    let url = tempDirectory.appendingPathComponent("nestedStruct")
+    let archiver = CodableArchiver<Container>(directory: url)
+    let value = Container(id: 1, values: [TestCodableValue(value: "one"), TestCodableValue(value: "two")])
+
+    #expect(archiver.set(value))
+    let result = archiver.get()
+    #expect(result == value)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveClassObject() throws {
+    let url = tempDirectory.appendingPathComponent("classObject")
+    let archiver = CodableArchiver<TestCodableClass<String>>(directory: url)
+    let value = TestCodableClass(value: "classValue")
+
+    #expect(archiver.set(value))
+    let result = archiver.get()
+    #expect(result == value)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveClassArray() throws {
+    let url = tempDirectory.appendingPathComponent("classArray")
+    let archiver = CodableArchiver<TestCodableClass<String>>(directory: url)
+    let values = [TestCodableClass(value: "one"), TestCodableClass(value: "two")]
+
+    #expect(archiver.set(values))
+
+    let path = archiver.filePathForKey(archiver.key)
+    guard let archived = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [Data] else {
+      #expect(false)
+      return
+    }
+    let decoded = archived.compactMap {
+      try? archiver.decoder.decode(TestCodableClass<String>.self, from: $0)
+    }
+    #expect(decoded == values)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveGenericStructObject() throws {
+    let url = tempDirectory.appendingPathComponent("genericStructObject")
+    let archiver = CodableArchiver<TestCodableStruct<String>>(directory: url)
+    let value = TestCodableStruct(value: "structValue")
+
+    #expect(archiver.set(value))
+    let result = archiver.get()
+    #expect(result == value)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveGenericStructArray() throws {
+    let url = tempDirectory.appendingPathComponent("genericStructArray")
+    let archiver = CodableArchiver<TestCodableStruct<String>>(directory: url)
+    let values = [TestCodableStruct(value: "one"), TestCodableStruct(value: "two")]
+
+    #expect(archiver.set(values))
+
+    let path = archiver.filePathForKey(archiver.key)
+    guard let archived = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [Data] else {
+      #expect(false)
+      return
+    }
+    let decoded = archived.compactMap {
+      try? archiver.decoder.decode(TestCodableStruct<String>.self, from: $0)
+    }
+    #expect(decoded == values)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveDataObject() throws {
+    let url = tempDirectory.appendingPathComponent("dataObject")
+    let archiver = CodableArchiver<Data>(directory: url)
+    let value = "dataValue".data(using: .utf8)!
+
+    #expect(archiver.set(value))
+    let result = archiver.get()
+    #expect(result == value)
+    try? archiver.clear()
+  }
+
+  @Test
+  func archiveDataArray() throws {
+    let url = tempDirectory.appendingPathComponent("dataArray")
+    let archiver = CodableArchiver<Data>(directory: url)
+    let values = ["one", "two"].compactMap { $0.data(using: .utf8) }
+
+    #expect(archiver.set(values))
+
+    let path = archiver.filePathForKey(archiver.key)
+    guard let archived = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [Data] else {
+      #expect(false)
+      return
+    }
+    let decoded = archived.compactMap { try? archiver.decoder.decode(Data.self, from: $0) }
+    #expect(decoded == values)
+    try? archiver.clear()
+  }
+
+  @Test
+  func missingDataReturnsNil() throws {
+    let url = tempDirectory.appendingPathComponent("missingData")
+    let archiver = CodableArchiver<TestCodableValue>(directory: url)
+
+    let result = archiver.get()
+    #expect(result == nil)
+  }
+}
+

--- a/Tests/WrkstrmFoundationTests/TestCodableClass.swift
+++ b/Tests/WrkstrmFoundationTests/TestCodableClass.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+final class TestCodableClass<Value: Codable & Equatable>: Codable, Equatable {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+
+  static func == (lhs: TestCodableClass<Value>, rhs: TestCodableClass<Value>) -> Bool {
+    lhs.value == rhs.value
+  }
+}
+

--- a/Tests/WrkstrmFoundationTests/TestCodableStruct.swift
+++ b/Tests/WrkstrmFoundationTests/TestCodableStruct.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct TestCodableStruct<Value: Codable & Equatable>: Codable, Equatable {
+  let value: Value
+}

--- a/Tests/WrkstrmFoundationTests/TestCodableValue.swift
+++ b/Tests/WrkstrmFoundationTests/TestCodableValue.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct TestCodableValue: Codable, Equatable {
+  let value: String
+}
+


### PR DESCRIPTION
## Summary
- use `archivedData(withRootObject:requiringSecureCoding:)` for archiving
- write archived data using `FileManager`
- add `CodableArchiver` unit tests for structs, generic classes, generic structs, and arrays
- extract test models into their own files to avoid placeholder names

## Testing
- `swift test --enable-test-discovery`


------
https://chatgpt.com/codex/tasks/task_e_688c449ab2d883339d452615e1c8bf68