### PR TITLE
Exclude RelativeDateTimeFormatter on Linux

### DIFF
--- a/Sources/WrkstrmFoundation/Extensions/Dates/RelativeDateTimeFormatter+Date.swift
+++ b/Sources/WrkstrmFoundation/Extensions/Dates/RelativeDateTimeFormatter+Date.swift
@@ -1,14 +1,8 @@
-#if os(Linux)
-  // Required due to the lack of support for DispatchQueue being Sendable on Linux platforms.
-  @preconcurrency import Foundation
-  #if canImport(FoundationInternationalization)
-    import FoundationInternationalization
-  #endif  // canImport(FoundationInternationalization)
-#else
-  import Foundation
-#endif
-
+// This functionality relies on `RelativeDateTimeFormatter`, which is not
+// implemented on Linux. Compile this extension only for non-Linux platforms.
 #if !os(Linux)
+  import Foundation
+
   extension RelativeDateTimeFormatter {
     /// Returns a non breaking localized string describing the relative time between the provided
     /// timestamp and now.


### PR DESCRIPTION
## Summary
- Guard RelativeDateTimeFormatter extension behind `#if !os(Linux)` so the formatter isn't available on Linux builds.

## Testing
- `swift test --skip-build`

------
https://chatgpt.com/codex/tasks/task_e_68915fb0fba48333addb9faa31faf202