### PR TITLE
Fix typo in networking logger comment

### DIFF
--- a/Sources/WrkstrmNetworking/Log+Networking.swift
+++ b/Sources/WrkstrmNetworking/Log+Networking.swift
@@ -28,7 +28,7 @@ extension Log {
 
   /// A static instance of `Log` configured for printing JSON-related networking messages.
   ///
-  /// - NOTE: This logger wil not truncate JSON payloads printed to the command line.
+  /// - NOTE: This logger will not truncate JSON payloads printed to the command line.
   ///
   /// This logger uses the "wrkstrm-networking" system, targeting the "json" category,
   /// and applies the `.print` style for straightforward output—useful for debugging


### PR DESCRIPTION
## Summary
- fix minor typo in networking log documentation

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6893cfed596083339b807a40f18f7897