### PR TITLE
Mark NotificationCenter observer block as Sendable

### DIFF
--- a/Sources/WrkstrmFoundation/Extensions/NotificationCenter+Transformers.swift
+++ b/Sources/WrkstrmFoundation/Extensions/NotificationCenter+Transformers.swift
@@ -70,7 +70,7 @@ extension NotificationCenter {
   @MainActor
   public func addObserver<A>(
     for transformer: Notification.Transformer<A>,
-    using block: @escaping ((A) -> Void),
+    using block: @escaping (@Sendable (A) -> Void),
   ) -> Notification.Token {
     let token = addObserver(forName: transformer.name, object: nil, queue: .main) { note in
       let value = transformer.transform(note)


### PR DESCRIPTION
## Summary
- mark addObserver callback closure as `@Sendable`

## Testing
- `swift test` *(fails: extra argument 'maxExposureLevel' in call in WrkstrmNetworking/Log+Networking.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689a9a8559bc8333be3421af16935d0f