### PR TITLE
Avoid trailing question mark when no query items

### DIFF
--- a/Sources/WrkstrmFoundation/Extensions/URL+URLQueryItem.swift
+++ b/Sources/WrkstrmFoundation/Extensions/URL+URLQueryItem.swift
@@ -25,7 +25,7 @@ extension URL {
   /// - Returns: A new `URL` with the query items added, or `nil` if the URL could not be constructed.
   public func withQueryItems(_ items: [URLQueryItem]) -> URL? {
     var components: URLComponents? = .init(url: self, resolvingAgainstBaseURL: false)
-    components?.queryItems = items
+    components?.queryItems = items.isEmpty ? nil : items
     return components?.url
   }
 

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
@@ -55,7 +55,7 @@ extension URLRequestConvertible where Self: HTTP.Request.Encodable {
       .replacingOccurrences(of: "//", with: "/")  // Clean up accidental double slashes
     var urlComponents = URLComponents(string: pathComponents)
     // Handle query items from URL.
-    urlComponents?.queryItems = options.queryItems
+    urlComponents?.queryItems = options.queryItems.isEmpty ? nil : options.queryItems
     var urlRequest = URLRequest(url: urlComponents?.url ?? URL(string: "")!)
     // Apply the requests HTTP method
     urlRequest.httpMethod = method.rawValue

--- a/Tests/WrkstrmFoundationTests/URLQueryItemTests.swift
+++ b/Tests/WrkstrmFoundationTests/URLQueryItemTests.swift
@@ -17,6 +17,13 @@ struct URLQueryItemTests {
   }
 
   @Test
+  func emptyQueryItemsDoesNotAppendQuestionMark() {
+    let base = URL(string: "https://example.com")!
+    let result = base.withQueryItems([])
+    #expect(result?.absoluteString == "https://example.com")
+  }
+
+  @Test
   func buildURLWithDictionary() {
     let base = URL(string: "https://example.com")!
     let result = base.withQueryItems(["foo": "bar", "baz": "qux"])

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -10,18 +10,18 @@ import WrkstrmLog
 import FoundationNetworking
 #endif
 
-@Suite("WrkstrmNetworking")
-struct WrkstrmNetworkingTests {
+  @Suite("WrkstrmNetworking")
+  struct WrkstrmNetworkingTests {
 
   init() {
     Log.globalExposureLevel = .trace
   }
 
-  @Test
-  func urlRequestEncoding() throws {
-    let env = MockEnvironment()
-    let request = SampleRequest()
-    let urlRequest = try request.asURLRequest(with: env, encoder: .snakecase)
+    @Test
+    func urlRequestEncoding() throws {
+      let env = MockEnvironment()
+      let request = SampleRequest()
+      let urlRequest = try request.asURLRequest(with: env, encoder: .snakecase)
 
     #expect(urlRequest.httpMethod == "POST")
     #expect(
@@ -35,6 +35,16 @@ struct WrkstrmNetworkingTests {
     )
     #expect(urlRequest.httpBody == expectedBody)
   }
+
+    @Test
+    func urlRequestWithoutQueryItems() throws {
+      let env = MockEnvironment()
+      var request = SampleRequest()
+      request.options = .init(timeout: 10, headers: ["X-Test": "1"])
+      let urlRequest = try request.asURLRequest(with: env, encoder: .snakecase)
+
+      #expect(urlRequest.url?.absoluteString == "https://example.com/v1/users")
+    }
 
   // MARK: - Error Handling
 


### PR DESCRIPTION
## Summary
- Avoid emitting `?` when URL query items list is empty
- Ensure request builder drops question mark when no query parameters
- Add regression tests for URLs without query items

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68a0542fd7b08333ae574b9558895142