### PR TITLE
Add PUT HTTP method and test coverage

### DIFF
--- a/Sources/WrkstrmNetworking/HTTP/HTTP+Method.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+Method.swift
@@ -7,6 +7,8 @@ extension HTTP {
     case get = "GET"
     /// The POST method submits data to be processed to the identified resource.
     case post = "POST"
+    /// The PUT method replaces all current representations of the target resource.
+    case put = "PUT"
     /// The PATCH method applies partial modifications to a resource.
     case patch = "PATCH"
     /// The DELETE method deletes the specified resource.

--- a/Tests/WrkstrmNetworkingTests/Support/SamplePutRequest.swift
+++ b/Tests/WrkstrmNetworkingTests/Support/SamplePutRequest.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@testable import WrkstrmNetworking
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct SamplePutRequest: HTTP.CodableURLRequest {
+  typealias ResponseType = [String: String]
+  typealias RequestBody = Body
+
+  struct Body: Codable, Equatable { let name: String }
+
+  var method: HTTP.Method { .put }
+  var path: String { "users" }
+  var body: Body? = .init(name: "Bob")
+  var options: HTTP.Request.Options = .init(
+    timeout: 10,
+    queryItems: [URLQueryItem(name: "debug", value: "true")],
+    headers: ["X-Test": "1"]
+  )
+}

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -37,6 +37,25 @@ struct WrkstrmNetworkingTests {
   }
 
   @Test
+  func urlRequestEncodingPut() throws {
+    let env = MockEnvironment()
+    let request = SamplePutRequest()
+    let urlRequest = try request.asURLRequest(with: env, encoder: .snakecase)
+
+    #expect(urlRequest.httpMethod == "PUT")
+    #expect(
+      urlRequest.url?.absoluteString
+        == "https://example.com/v1/users?debug=true"
+    )
+    #expect(urlRequest.value(forHTTPHeaderField: "X-Test") == "1")
+
+    let expectedBody = try JSONEncoder.snakecase.encode(
+      SamplePutRequest.Body(name: "Bob")
+    )
+    #expect(urlRequest.httpBody == expectedBody)
+  }
+
+  @Test
   func urlRequestWithoutQueryItems() throws {
     let env = MockEnvironment()
     var request = SampleRequest()


### PR DESCRIPTION
## Summary
- add PUT case to HTTP.Method
- cover PUT requests with SamplePutRequest and unit test

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a43a6dc26883338f1897e6ec4fca8e