### PR TITLE
Allow injecting session configuration for JSON client tests

### DIFF
--- a/Sources/WrkstrmNetworking/HTTP/HTTP+JSONClient.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+JSONClient.swift
@@ -24,14 +24,15 @@ extension HTTP {
     /// Initializes a new JSONClient.
     /// - Parameters:
     ///   - environment: The environment configuration to use.
-    ///   - headers: Default HTTP headers for requests.
-    ///   - decoder: The JSON decoder (default is .snakecase).
+    ///   - json: The JSON encoder and decoder pair.
+    ///   - configuration: Optional session configuration allowing callers to
+    ///     inject custom `URLProtocol` implementations for testing.
     public init(
       environment: any HTTP.Environment,
-      json: (requestEncoder: JSONEncoder, responseDecoder: JSONDecoder)
+      json: (requestEncoder: JSONEncoder, responseDecoder: JSONDecoder),
+      configuration: URLSessionConfiguration = .default
     ) {
       self.json = json
-      let configuration: URLSessionConfiguration = .default
       configuration.httpAdditionalHeaders = environment.headers
       self.configuration = configuration
       session = .init(configuration: configuration)

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+JSONClient.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+JSONClient.swift
@@ -35,7 +35,10 @@ extension HTTP {
       self.json = json
       configuration.httpAdditionalHeaders = environment.headers
       self.configuration = configuration
-      session = .init(configuration: configuration)
+      let configCopy = (configuration.copy() as! URLSessionConfiguration)
+      configCopy.httpAdditionalHeaders = environment.headers
+      self.configuration = configCopy
+      session = .init(configuration: configCopy)
       self.environment = environment
     }
 

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -69,13 +69,14 @@ struct WrkstrmNetworkingTests {
 
   @Test
   func errorResponseHandling() async {
-    _ = URLProtocol.registerClass(MockURLProtocol.self)
-    defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
 
     let env = MockEnvironment()
     let client = HTTP.JSONClient(
       environment: env,
-      json: (.snakecase, .snakecase)
+      json: (.snakecase, .snakecase),
+      configuration: configuration
     )
 
     MockURLProtocol.handler = { request in


### PR DESCRIPTION
## Summary
- allow providing a custom `URLSessionConfiguration` when creating `HTTP.JSONClient`
- use a session with `MockURLProtocol` in tests to mock network responses

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68a48c5ebb508333a6d27f7e1241f130