### PR TITLE
Canonicalize query parameter order

### DIFF
--- a/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
@@ -54,8 +54,10 @@ extension URLRequestConvertible where Self: HTTP.Request.Encodable {
       .joined(separator: "/")
       .replacingOccurrences(of: "//", with: "/")  // Clean up accidental double slashes
     var urlComponents = URLComponents(string: pathComponents)
-    // Handle query items from URL.
-    urlComponents?.queryItems = options.queryItems.isEmpty ? nil : options.queryItems
+    // Handle query items from URL. Query items are sorted by key to ensure
+    // a canonical URL which improves request caching behaviour.
+    let sortedQueryItems = options.queryItems.sorted { $0.name < $1.name }
+    urlComponents?.queryItems = sortedQueryItems.isEmpty ? nil : sortedQueryItems
     var urlRequest = URLRequest(url: urlComponents?.url ?? URL(string: "")!)
     // Apply the requests HTTP method
     urlRequest.httpMethod = method.rawValue

--- a/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
+++ b/Sources/WrkstrmNetworking/HTTP/HTTP+URLRequestConvertible.swift
@@ -55,7 +55,7 @@ extension URLRequestConvertible where Self: HTTP.Request.Encodable {
       .replacingOccurrences(of: "//", with: "/")  // Clean up accidental double slashes
     var urlComponents = URLComponents(string: pathComponents)
     // Handle query items from URL. Query items are sorted by key to ensure
-    // a canonical URL which improves request caching behaviour.
+    // a canonical URL which improves request caching behavior.
     let sortedQueryItems = options.queryItems.sorted { $0.name < $1.name }
     urlComponents?.queryItems = sortedQueryItems.isEmpty ? nil : sortedQueryItems
     var urlRequest = URLRequest(url: urlComponents?.url ?? URL(string: "")!)

--- a/Tests/WrkstrmNetworkingTests/Support/UnsortedQueryRequest.swift
+++ b/Tests/WrkstrmNetworkingTests/Support/UnsortedQueryRequest.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+@testable import WrkstrmNetworking
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct UnsortedQueryRequest: HTTP.CodableURLRequest {
+  typealias ResponseType = [String: String]
+
+  var method: HTTP.Method { .get }
+  var path: String { "users" }
+  var options: HTTP.Request.Options = .init(
+    queryItems: [
+      URLQueryItem(name: "b", value: "1"),
+      URLQueryItem(name: "a", value: "2"),
+      URLQueryItem(name: "c", value: "3"),
+    ]
+  )
+}

--- a/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
+++ b/Tests/WrkstrmNetworkingTests/WrkstrmNetworkingTests.swift
@@ -65,6 +65,16 @@ struct WrkstrmNetworkingTests {
     #expect(urlRequest.url?.absoluteString == "https://example.com/v1/users")
   }
 
+  @Test
+  func queryItemsAreSortedByKey() throws {
+    let env = MockEnvironment()
+    let urlRequest = try UnsortedQueryRequest().asURLRequest(with: env, encoder: .snakecase)
+    #expect(
+      urlRequest.url?.absoluteString
+        == "https://example.com/v1/users?a=2&b=1&c=3"
+    )
+  }
+
   // Ensures that combining a base URL ending with a slash and a request
   // path starting with a slash doesn't produce a double slash. A "//"
   // segment after the scheme can lead servers to treat the URL differently


### PR DESCRIPTION
## Summary
- sort query parameters before constructing URL requests so cache keys are stable
- add regression test to ensure query parameters are sorted

## Testing
- `swift test` *(fails: cannot find 'StringError' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a730595d9883338fed9352baa03c8b